### PR TITLE
support deps where module is not in the top level of the directory

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,11 +13,13 @@
 # limitations under the License.
 workspace(name = "io_bazel_rules_python")
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
 # Skydoc stuff
 git_repository(
     name = "io_bazel_rules_sass",
     remote = "https://github.com/bazelbuild/rules_sass.git",
-    tag = "0.0.3",
+    commit = "8ccf4f1c351928b55d5dddf3672e3667f6978d60"
 )
 
 load("@io_bazel_rules_sass//sass:sass.bzl", "sass_repositories")


### PR DESCRIPTION
Right now python_rules does not support pip imports where the module is not in the top-level of the directory (such as tensorflow). This patch would fix that; see the proposed changes to `rules_python/why.py`. 

Incorporating this into Applied's Bazel build would require running the `update_tools.sh` script in this repo to generate a new `.par` file that we could import as a dependency. Right now this script is broken because of changes to Bazel itself and I am in the process of debugging it. 